### PR TITLE
Fix Linux native module packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           npm ci
       - run: |
           sudo apt-get update
-          sudo apt-get install -y rpm fakeroot dpkg 7zip
+          sudo apt-get install -y build-essential python3 make g++ rpm fakeroot dpkg 7zip file ripgrep
       - run: node scripts/sync-upstream.js --force --skip-win
       - run: node scripts/patch-all.js mac-${{ matrix.arch }}
       - run: npm run build:linux-${{ matrix.arch }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 # Build outputs
 out/
 dist/
+.cache/
 
 # Upstream ASAR extracts and build-time copies (all generated)
 src/

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,6 +1,71 @@
 const { FuseV1Options, FuseVersion } = require("@electron/fuses");
 const path = require("path");
 const fs = require("fs");
+const {
+  copyLinuxExecutable,
+  resolveCodexVendor,
+  resolveRipgrepVendor,
+} = require("./scripts/linux-native-utils");
+
+function hasCommand(command) {
+  const pathEntries = (process.env.PATH || "").split(path.delimiter);
+  return pathEntries.some((entry) => {
+    const candidate = path.join(entry, command);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function buildMode() {
+  try {
+    return fs.readFileSync(path.join(__dirname, "src", ".build-mode"), "utf-8").trim();
+  } catch {
+    return "upstream-asar";
+  }
+}
+
+function linuxPlatformKey(arch) {
+  return arch === "arm64" ? "linux-arm64" : "linux-x64";
+}
+
+function copyStagedOrResolvedLinuxResource(resourcesPath, platformKey, name, resolver) {
+  const staged = path.join(__dirname, "src", ".linux-resources", platformKey, name);
+  const source = fs.existsSync(staged) ? staged : resolver(platformKey);
+  if (!source) {
+    throw new Error(`Linux ${name} ELF not found for ${platformKey}`);
+  }
+  const dest = path.join(resourcesPath, name);
+  copyLinuxExecutable(source, dest, platformKey, name);
+  console.log(`   [linux] ${name}: ${path.relative(__dirname, source)} -> Resources/${name}`);
+}
+
+function copyLinuxResources(resourcesPath, platformKey) {
+  const stagedDir = path.join(__dirname, "src", ".linux-resources", platformKey);
+  if (!fs.existsSync(stagedDir)) return 0;
+
+  let copied = 0;
+  const copyDir = (sourceDir, destDir) => {
+    fs.mkdirSync(destDir, { recursive: true });
+    for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+      if (entry.name === "app.asar" || entry.name === "app.asar.unpacked") continue;
+      const sourcePath = path.join(sourceDir, entry.name);
+      const destPath = path.join(destDir, entry.name);
+      if (entry.isDirectory()) {
+        copyDir(sourcePath, destPath);
+      } else if (!entry.isSymbolicLink()) {
+        fs.copyFileSync(sourcePath, destPath);
+        copied++;
+      }
+    }
+  };
+
+  copyDir(stagedDir, resourcesPath);
+  return copied;
+}
 
 module.exports = {
   packagerConfig: {
@@ -11,16 +76,12 @@ module.exports = {
     // Build mode is set by prepare-src.js via src/.build-mode marker file.
     // "upstream-asar": mac/win — we provide pre-built app.asar, forge skips ASAR packing.
     // "linux": forge packs ASAR from src/ content (needs electron-rebuild).
-    asar: (() => {
-      try {
-        return fs.readFileSync(path.join(__dirname, "src", ".build-mode"), "utf-8").trim() === "upstream-asar"
-          ? false
-          : { unpack: "{**/*.node,**/node-pty/build/Release/spawn-helper,**/node-pty/prebuilds/*/spawn-helper}" };
-      } catch { return false; }
-    })(),
+    asar: (() => buildMode() === "upstream-asar"
+      ? false
+      : { unpack: "{**/*.node,**/node-pty/build/Release/spawn-helper,**/node-pty/prebuilds/*/spawn-helper}" }
+    )(),
     ignore: (() => {
-      let mode = "upstream-asar";
-      try { mode = fs.readFileSync(path.join(__dirname, "src", ".build-mode"), "utf-8").trim(); } catch {}
+      const mode = buildMode();
       return mode === "upstream-asar"
         ? (filePath) => {
             // Allow only package.json + stub main entry (forge validates it)
@@ -72,14 +133,15 @@ module.exports = {
       name: "@electron-forge/maker-deb",
       config: { options: { name: "codex", productName: "Codex", genericName: "AI Coding Assistant", categories: ["Development", "Utility"], bin: "Codex", maintainer: "Cometix Space", homepage: "https://github.com/Haleclipse/CodexDesktop-Rebuild", icon: "./resources/electron.png" } },
     },
-    {
+    ...(!["linux"].includes(process.platform) || hasCommand("rpm") ? [{
       name: "@electron-forge/maker-rpm",
       config: { options: { name: "codex", productName: "Codex", genericName: "AI Coding Assistant", categories: ["Development", "Utility"], bin: "Codex", license: "Apache-2.0", homepage: "https://github.com/Haleclipse/CodexDesktop-Rebuild", icon: "./resources/electron.png" } },
-    },
+    }] : []),
     { name: "@electron-forge/maker-zip", platforms: ["linux"] },
   ],
   plugins: [
-    // No auto-unpack-natives — we provide upstream app.asar.unpacked directly
+    // No auto-unpack-natives: mac/win provide upstream app.asar.unpacked;
+    // Linux uses Forge ASAR packing after electron-rebuild in src/node_modules.
     {
       name: "@electron-forge/plugin-fuses",
       config: {
@@ -94,19 +156,29 @@ module.exports = {
     },
   ],
   hooks: {
-    // Copy everything from the platform dir to the app's Resources:
+    // Copy everything from the platform dir to the app's Resources for mac/win:
     // - app.asar (repacked by prepare-src with patches applied)
     // - app.asar.unpacked/ (upstream native modules, untouched)
     // - All other resources (codex CLI, rg, plugins, native, etc.)
     //
-    // Forge's own ASAR packing is disabled (asar: false).
-    // buildPath points to the app dir — we put app.asar alongside it.
+    // Forge's own ASAR packing is disabled for upstream-asar builds.
+    // Linux must not copy app.asar/app.asar.unpacked from src/mac-*.
     packageAfterCopy: async (config, buildPath, electronVersion, platform, arch) => {
       console.log(`\n-- packageAfterCopy: ${platform}-${arch}`);
 
       const resourcesPath = path.dirname(buildPath);
+
+      if (platform === "linux") {
+        const platformKey = linuxPlatformKey(arch);
+        const copied = copyLinuxResources(resourcesPath, platformKey);
+        console.log(`   [linux] copied ${copied} sanitized resource files`);
+        copyStagedOrResolvedLinuxResource(resourcesPath, platformKey, "codex", resolveCodexVendor);
+        copyStagedOrResolvedLinuxResource(resourcesPath, platformKey, "rg", resolveRipgrepVendor);
+        console.log("   [linux] app.asar/app.asar.unpacked left to Forge output");
+        return;
+      }
+
       const platformKey = platform === "win32" ? "win"
-        : platform === "linux" ? `mac-${arch}`
         : `mac-${arch}`;
 
       const platformDir = path.join(__dirname, "src", platformKey);

--- a/package.json
+++ b/package.json
@@ -18,14 +18,17 @@
     "build:mac": "npm run build:mac-arm64 && npm run build:mac-x64",
     "build:win-x64": "node scripts/build-from-upstream.js --platform win",
     "build:win": "npm run build:win-x64",
-    "build:linux-x64": "node scripts/prepare-src.js --platform linux-x64 && npm run rebuild:native && rm -rf out && electron-forge make --platform=linux --arch=x64",
-    "build:linux-arm64": "node scripts/prepare-src.js --platform linux-arm64 && npm run rebuild:native && rm -rf out && electron-forge make --platform=linux --arch=arm64",
+    "build:linux-x64": "node scripts/prepare-src.js --platform linux-x64 && node scripts/patch-linux-rendering.js linux-x64 && npm run rebuild:native:linux-x64 && node scripts/prepare-src.js --strip-linux-native-extras && rm -rf out && electron-forge make --platform=linux --arch=x64 && node scripts/validate-linux-package.js --arch x64",
+    "build:linux-arm64": "node scripts/prepare-src.js --platform linux-arm64 && node scripts/patch-linux-rendering.js linux-arm64 && npm run rebuild:native:linux-arm64 && node scripts/prepare-src.js --strip-linux-native-extras && rm -rf out && electron-forge make --platform=linux --arch=arm64 && node scripts/validate-linux-package.js --arch arm64",
     "build:linux": "npm run build:linux-x64 && npm run build:linux-arm64",
     "build:all": "npm run build:mac && npm run build:win && npm run build:linux",
     "sync": "node scripts/sync-upstream.js",
     "check-update": "node scripts/check-update.js",
     "bump-version": "node scripts/bump-version.js",
-    "rebuild:native": "electron-rebuild"
+    "rebuild:native": "electron-rebuild",
+    "rebuild:native:linux-x64": "npm_config_devdir=.cache/electron-gyp electron-rebuild -m src -a x64 -f -o better-sqlite3,node-pty",
+    "rebuild:native:linux-arm64": "npm_config_devdir=.cache/electron-gyp electron-rebuild -m src -a arm64 -f -o better-sqlite3,node-pty",
+    "validate:linux-package": "node scripts/validate-linux-package.js"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.10.2",
@@ -62,7 +65,7 @@
     "zod": "^4.1.13"
   },
   "codexBuildFlavor": "prod",
-  "codexBuildNumber": "1272",
-  "codexSparkleFeedUrl": "https://persistent.oaistatic.com/codex-app-prod/appcast.xml",
+  "codexBuildNumber": "2575",
+  "codexSparkleFeedUrl": "https://persistent.oaistatic.com/codex-app-prod/appcast-x64.xml",
   "codexSparklePublicKey": "rhcBvttuqDFriyNqwTQJR3L4UT1WjIK4QxtwtwusVic="
 }

--- a/scripts/linux-native-utils.js
+++ b/scripts/linux-native-utils.js
@@ -1,0 +1,215 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+
+const TARGET_TRIPLE_MAP = {
+  "mac-arm64": "aarch64-apple-darwin",
+  "mac-x64": "x86_64-apple-darwin",
+  "linux-x64": "x86_64-unknown-linux-musl",
+  "linux-arm64": "aarch64-unknown-linux-musl",
+  "win": "x86_64-pc-windows-msvc",
+};
+
+const COMETIX_PLATFORM_PACKAGE = {
+  "linux-x64": "codex-linux-x64",
+  "linux-arm64": "codex-linux-arm64",
+  "mac-arm64": "codex-darwin-arm64",
+  "mac-x64": "codex-darwin-x64",
+  "win": "codex-win32-x64",
+};
+
+const PLATFORM_SUFFIX = {
+  "linux-x64": "linux-x64",
+  "linux-arm64": "linux-arm64",
+  "mac-arm64": "darwin-arm64",
+  "mac-x64": "darwin-x64",
+  "win": "win32-x64",
+};
+
+const EXPECTED_ELF_MACHINE = {
+  "linux-x64": 62,
+  "linux-arm64": 183,
+};
+
+function readMagic(filePath, size = 20) {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(size);
+    const bytesRead = fs.readSync(fd, buffer, 0, size, 0);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function isElf(filePath) {
+  try {
+    const magic = readMagic(filePath, 4);
+    return magic[0] === 0x7f && magic[1] === 0x45 && magic[2] === 0x4c && magic[3] === 0x46;
+  } catch {
+    return false;
+  }
+}
+
+function isMachO(filePath) {
+  try {
+    const magic = readMagic(filePath, 4);
+    const hex = magic.toString("hex");
+    return [
+      "feedface",
+      "feedfacf",
+      "cefaedfe",
+      "cffaedfe",
+      "cafebabe",
+      "bebafeca",
+    ].includes(hex);
+  } catch {
+    return false;
+  }
+}
+
+function getElfMachine(filePath) {
+  if (!isElf(filePath)) return null;
+  const header = readMagic(filePath, 20);
+  const endian = header[5];
+  if (endian === 1) return header.readUInt16LE(18);
+  if (endian === 2) return header.readUInt16BE(18);
+  return null;
+}
+
+function assertLinuxElf(filePath, platform, label) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${label} not found: ${filePath}`);
+  }
+  if (!isElf(filePath)) {
+    throw new Error(`${label} is not an ELF binary: ${filePath}`);
+  }
+  const expected = EXPECTED_ELF_MACHINE[platform];
+  const actual = getElfMachine(filePath);
+  if (expected && actual !== expected) {
+    throw new Error(`${label} has ELF machine ${actual}, expected ${expected} for ${platform}: ${filePath}`);
+  }
+}
+
+function commandPath(command) {
+  try {
+    return execSync(`command -v ${command}`, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function findExisting(paths) {
+  return paths.find((candidate) => candidate && fs.existsSync(candidate)) || null;
+}
+
+function npmPackCometix(platform) {
+  const suffix = PLATFORM_SUFFIX[platform];
+  if (!suffix) return null;
+
+  let baseVer;
+  try {
+    baseVer = execSync("npm view @cometix/codex version", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return null;
+  }
+
+  const spec = `@cometix/codex@${baseVer}-${suffix}`;
+  console.log(`   [codex] fetching ${spec} via npm pack...`);
+
+  const tmpDir = path.join(os.tmpdir(), "cometix-codex-pack", platform);
+  const extractDir = path.join(tmpDir, "extracted");
+  fs.mkdirSync(tmpDir, { recursive: true });
+
+  try {
+    const tgzName = execSync(`npm pack ${spec} --pack-destination "${tmpDir}"`, {
+      cwd: tmpDir,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim().split("\n").pop();
+
+    if (fs.existsSync(extractDir)) fs.rmSync(extractDir, { recursive: true, force: true });
+    fs.mkdirSync(extractDir, { recursive: true });
+    execSync(`tar xzf "${path.join(tmpDir, tgzName)}" -C "${extractDir}"`, { stdio: "pipe" });
+    return path.join(extractDir, "package");
+  } catch (e) {
+    console.log(`   [!] npm pack failed: ${e.message}`);
+    return null;
+  }
+}
+
+function resolveVendorFile(platform, relativeParts) {
+  const triple = TARGET_TRIPLE_MAP[platform];
+  if (!triple) return null;
+
+  const cometixPlatformPackage = COMETIX_PLATFORM_PACKAGE[platform];
+  const candidates = [
+    cometixPlatformPackage && path.join(PROJECT_ROOT, "node_modules", "@cometix", cometixPlatformPackage, "vendor", triple, ...relativeParts),
+    path.join(PROJECT_ROOT, "node_modules", "@cometix", "codex", "vendor", triple, ...relativeParts),
+    path.join(PROJECT_ROOT, "node_modules", "@openai", "codex", "vendor", triple, ...relativeParts),
+  ];
+
+  const existing = findExisting(candidates);
+  if (existing) return existing;
+
+  const packed = npmPackCometix(platform);
+  if (!packed) return null;
+
+  const packedPath = path.join(packed, "vendor", triple, ...relativeParts);
+  return fs.existsSync(packedPath) ? packedPath : null;
+}
+
+function resolveCodexVendor(platform) {
+  const binName = platform === "win" ? "codex.exe" : "codex";
+  const resolved = resolveVendorFile(platform, ["codex", binName]);
+  if (resolved) return resolved;
+
+  const triple = TARGET_TRIPLE_MAP[platform];
+  const rgPath = commandPath("rg");
+  if (triple && rgPath) {
+    const vendorNeedle = `${path.sep}vendor${path.sep}${triple}${path.sep}path${path.sep}rg`;
+    if (rgPath.endsWith(vendorNeedle)) {
+      const vendorRoot = rgPath.slice(0, -vendorNeedle.length);
+      const siblingCodex = path.join(vendorRoot, "vendor", triple, "codex", binName);
+      if (fs.existsSync(siblingCodex)) return siblingCodex;
+    }
+  }
+
+  return null;
+}
+
+function resolveRipgrepVendor(platform) {
+  const systemRg = commandPath("rg");
+  if (systemRg && isElf(systemRg)) {
+    const expected = EXPECTED_ELF_MACHINE[platform];
+    if (!expected || getElfMachine(systemRg) === expected) return systemRg;
+  }
+  return resolveVendorFile(platform, ["path", platform === "win" ? "rg.exe" : "rg"]);
+}
+
+function copyLinuxExecutable(source, dest, platform, label) {
+  assertLinuxElf(source, platform, label);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(source, dest);
+  fs.chmodSync(dest, 0o755);
+}
+
+module.exports = {
+  TARGET_TRIPLE_MAP,
+  assertLinuxElf,
+  copyLinuxExecutable,
+  getElfMachine,
+  isElf,
+  isMachO,
+  resolveCodexVendor,
+  resolveRipgrepVendor,
+};

--- a/scripts/patch-linux-rendering.js
+++ b/scripts/patch-linux-rendering.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Linux compositor patch for upstream macOS app bundles.
+ *
+ * The upstream desktop UI is optimized for macOS vibrancy/transparent windows.
+ * On Linux, transparent or semi-transparent Electron surfaces can leave repaint
+ * trails under some compositors when moving the window or hovering sidebar rows.
+ * Force Linux primary/secondary windows onto the opaque rendering path while
+ * leaving small overlay/popup windows transparent.
+ */
+const fs = require("fs");
+const path = require("path");
+const { locateBundles, relPath, SRC_DIR } = require("./patch-util");
+
+function replaceOnce(code, from, to, label, patches) {
+  if (code.includes(to)) return code;
+  const index = code.indexOf(from);
+  if (index === -1) {
+    throw new Error(`Pattern not found for ${label}`);
+  }
+  patches.push(label);
+  return code.slice(0, index) + to + code.slice(index + from.length);
+}
+
+function writeIfChanged(bundle, before, after, patches, check) {
+  if (patches.length === 0) {
+    console.log(`  [ok] ${relPath(bundle.path)}: already patched`);
+    return;
+  }
+  if (check) {
+    console.log(`  [?] ${relPath(bundle.path)}: ${patches.join(", ")}`);
+    return;
+  }
+  fs.writeFileSync(bundle.path, after, "utf-8");
+  console.log(`  [ok] ${relPath(bundle.path)}: ${patches.join(", ")}`);
+}
+
+function patchMainBundle(bundle, check) {
+  const before = fs.readFileSync(bundle.path, "utf-8");
+  let code = before;
+  const patches = [];
+
+  code = replaceOnce(
+    code,
+    "function QW({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`win32`&&!YW(t)?n?{backgroundColor:r?AW:jW,backgroundMaterial:`none`}:{backgroundColor:kW,backgroundMaterial:`mica`}:{backgroundColor:kW,backgroundMaterial:null}}",
+    "function QW({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`linux`&&!YW(t)?{backgroundColor:r?AW:jW,backgroundMaterial:null}:e===`win32`&&!YW(t)?n?{backgroundColor:r?AW:jW,backgroundMaterial:`none`}:{backgroundColor:kW,backgroundMaterial:`mica`}:{backgroundColor:kW,backgroundMaterial:null}}",
+    "linux opaque BrowserWindow background",
+    patches,
+  );
+
+  code = replaceOnce(
+    code,
+    "function eG({appearance:e,opaqueWindowsEnabled:t,platform:n}){switch(e){case`browserCommentPopup`:",
+    "function eG({appearance:e,opaqueWindowsEnabled:t,platform:n}){if(n===`linux`&&(e===`primary`||e===`secondary`))return{titleBarStyle:`default`,transparent:!1};switch(e){case`browserCommentPopup`:",
+    "linux non-transparent primary windows",
+    patches,
+  );
+
+  writeIfChanged(bundle, before, code, patches, check);
+}
+
+function patchRendererBundle(bundle, check) {
+  const before = fs.readFileSync(bundle.path, "utf-8");
+  let code = before;
+  const patches = [];
+
+  code = replaceOnce(
+    code,
+    "document.documentElement.dataset.codexOs=FF(),",
+    "document.documentElement.dataset.codexOs=FF(),document.documentElement.dataset.codexOs===`linux`&&document.documentElement.classList.add(`electron-opaque`),",
+    "linux electron-opaque class at startup",
+    patches,
+  );
+
+  code = replaceOnce(
+    code,
+    "if(C.opaqueWindows&&!wi()){e.classList.add(`electron-opaque`);return}e.classList.remove(`electron-opaque`)",
+    "if((document.documentElement.dataset.codexOs===`linux`||C.opaqueWindows)&&!wi()){e.classList.add(`electron-opaque`);return}e.classList.remove(`electron-opaque`)",
+    "keep electron-opaque on linux",
+    patches,
+  );
+
+  writeIfChanged(bundle, before, code, patches, check);
+}
+
+function patchCssBundle(bundle, check) {
+  const before = fs.readFileSync(bundle.path, "utf-8");
+  const rule = "[data-codex-window-type=electron][data-codex-os=linux]{background-color:var(--color-background-surface-under);background-image:none}[data-codex-window-type=electron][data-codex-os=linux] body{background-color:var(--color-background-surface-under);background-image:none}";
+  if (before.includes(rule)) {
+    console.log(`  [ok] ${relPath(bundle.path)}: already patched`);
+    return;
+  }
+  if (check) {
+    console.log(`  [?] ${relPath(bundle.path)}: append linux opaque CSS`);
+    return;
+  }
+  fs.writeFileSync(bundle.path, before + rule, "utf-8");
+  console.log(`  [ok] ${relPath(bundle.path)}: appended linux opaque CSS`);
+}
+
+function patchPlatform(platform, check) {
+  const mainBundles = locateBundles({ dir: "build", pattern: /^main-.*\.js$/, platform });
+  const rendererBundles = locateBundles({ dir: "assets", pattern: /^app-main-.*\.js$/, platform });
+  const cssBundles = locateBundles({ dir: "assets", pattern: /^app-main-.*\.css$/, platform });
+
+  if (mainBundles.length === 0) throw new Error(`No main bundle found for ${platform}`);
+  if (rendererBundles.length === 0) throw new Error(`No renderer app-main bundle found for ${platform}`);
+  if (cssBundles.length === 0) throw new Error(`No renderer app-main CSS found for ${platform}`);
+
+  for (const bundle of mainBundles) patchMainBundle(bundle, check);
+  for (const bundle of rendererBundles) patchRendererBundle(bundle, check);
+  for (const bundle of cssBundles) patchCssBundle(bundle, check);
+}
+
+function locateFlatBundles({ dir, pattern }) {
+  const baseDir = dir === "build"
+    ? path.join(SRC_DIR, ".vite", "build")
+    : path.join(SRC_DIR, "webview", "assets");
+  if (!fs.existsSync(baseDir)) return [];
+  const files = fs.readdirSync(baseDir).filter((file) => pattern.test(file));
+  return files.map((file) => ({ platform: "linux", path: path.join(baseDir, file) }));
+}
+
+function patchFlatLinux(check) {
+  const mainBundles = locateFlatBundles({ dir: "build", pattern: /^main-.*\.js$/ });
+  const rendererBundles = locateFlatBundles({ dir: "assets", pattern: /^app-main-.*\.js$/ });
+  const cssBundles = locateFlatBundles({ dir: "assets", pattern: /^app-main-.*\.css$/ });
+
+  if (mainBundles.length === 0) throw new Error("No flat Linux main bundle found in src/.vite/build");
+  if (rendererBundles.length === 0) throw new Error("No flat Linux renderer app-main bundle found in src/webview/assets");
+  if (cssBundles.length === 0) throw new Error("No flat Linux renderer app-main CSS found in src/webview/assets");
+
+  for (const bundle of mainBundles) patchMainBundle(bundle, check);
+  for (const bundle of rendererBundles) patchRendererBundle(bundle, check);
+  for (const bundle of cssBundles) patchCssBundle(bundle, check);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const check = args.includes("--check");
+  if (check) console.log("  [info] check mode validates patch targets only");
+
+  const platform = args.find((arg) =>
+    ["mac-arm64", "mac-x64", "win", "unix", "linux", "linux-x64", "linux-arm64"].includes(arg),
+  );
+  if (platform === "win") {
+    console.log("  [skip] Linux rendering patch does not apply to Windows");
+    return;
+  }
+  if (platform?.startsWith("linux")) {
+    patchFlatLinux(check);
+    return;
+  }
+
+  const platforms = platform && platform !== "unix"
+    ? [platform]
+    : ["mac-arm64", "mac-x64"].filter((target) =>
+        fs.existsSync(path.join(__dirname, "..", "src", target, "_asar")),
+      );
+
+  for (const target of platforms) patchPlatform(target, check);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`  [x] ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/patch-linux-rendering.js
+++ b/scripts/patch-linux-rendering.js
@@ -22,6 +22,111 @@ function replaceOnce(code, from, to, label, patches) {
   return code.slice(0, index) + to + code.slice(index + from.length);
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function patchOpaqueBackground(code, patches) {
+  const label = "linux opaque BrowserWindow background";
+  const from = "function QW({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`win32`&&!YW(t)?n?{backgroundColor:r?AW:jW,backgroundMaterial:`none`}:{backgroundColor:kW,backgroundMaterial:`mica`}:{backgroundColor:kW,backgroundMaterial:null}}";
+  const to = "function QW({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`linux`&&!YW(t)?{backgroundColor:r?AW:jW,backgroundMaterial:null}:e===`win32`&&!YW(t)?n?{backgroundColor:r?AW:jW,backgroundMaterial:`none`}:{backgroundColor:kW,backgroundMaterial:`mica`}:{backgroundColor:kW,backgroundMaterial:null}}";
+
+  if (code.includes(to)) return code;
+  if (code.includes(from)) {
+    patches.push(label);
+    return code.replace(from, to);
+  }
+
+  const fnPattern = /function\s+([A-Za-z_$][\w$]*)\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return ([\s\S]*?backgroundMaterial:null\}\})/g;
+  let match;
+  while ((match = fnPattern.exec(code)) !== null) {
+    const [, , platformVar, appearanceVar, opaqueVar, , body] = match;
+    if (body.includes(`${platformVar}===\`linux\`&&!`)) return code;
+
+    const winCondition = `${platformVar}===\`win32\`&&!`;
+    if (!body.startsWith(winCondition)) continue;
+
+    const winPattern = new RegExp(
+      `${escapeRegExp(platformVar)}===\`win32\`&&!([A-Za-z_$][\\w$]*)\\(${escapeRegExp(appearanceVar)}\\)\\?${escapeRegExp(opaqueVar)}\\?\\{backgroundColor:([\\s\\S]*?),backgroundMaterial:\`none\`\\}:`,
+    );
+    const winMatch = body.match(winPattern);
+    if (!winMatch) continue;
+
+    const transparentAppearanceFn = winMatch[1];
+    const opaqueBackgroundColor = winMatch[2];
+    const prefix = match[0].slice(0, match[0].length - body.length);
+    const replacement = `${prefix}${platformVar}===\`linux\`&&!${transparentAppearanceFn}(${appearanceVar})?{backgroundColor:${opaqueBackgroundColor},backgroundMaterial:null}:${body}`;
+    patches.push(label);
+    return code.slice(0, match.index) + replacement + code.slice(match.index + match[0].length);
+  }
+
+  throw new Error(`Pattern not found for ${label}`);
+}
+
+function patchLinuxWindowOptions(code, patches) {
+  const label = "linux non-transparent primary windows";
+  const from = "function eG({appearance:e,opaqueWindowsEnabled:t,platform:n}){switch(e){case`browserCommentPopup`:";
+  const to = "function eG({appearance:e,opaqueWindowsEnabled:t,platform:n}){if(n===`linux`&&(e===`primary`||e===`secondary`))return{titleBarStyle:`default`,transparent:!1};switch(e){case`browserCommentPopup`:";
+
+  if (code.includes(to)) return code;
+  if (code.includes(from)) {
+    patches.push(label);
+    return code.replace(from, to);
+  }
+
+  const fnPattern = /(function\s+[A-Za-z_$][\w$]*\(\{appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)\{)(switch\(\2\)\{case`browserCommentPopup`:)/;
+  const match = code.match(fnPattern);
+  if (!match) throw new Error(`Pattern not found for ${label}`);
+
+  const [, prefix, appearanceVar, , platformVar, switchBody] = match;
+  const guard = `if(${platformVar}===\`linux\`&&(${appearanceVar}===\`primary\`||${appearanceVar}===\`secondary\`))return{titleBarStyle:\`default\`,transparent:!1};`;
+  if (code.includes(guard)) return code;
+
+  patches.push(label);
+  return code.slice(0, match.index) + prefix + guard + switchBody + code.slice(match.index + match[0].length);
+}
+
+function patchElectronOpaqueStartup(code, patches) {
+  const label = "linux electron-opaque class at startup";
+  const from = "document.documentElement.dataset.codexOs=FF(),";
+  const to = "document.documentElement.dataset.codexOs=FF(),document.documentElement.dataset.codexOs===`linux`&&document.documentElement.classList.add(`electron-opaque`),";
+
+  if (code.includes(to)) return code;
+  if (code.includes(from)) {
+    patches.push(label);
+    return code.replace(from, to);
+  }
+
+  const pattern = /document\.documentElement\.dataset\.codexOs=([A-Za-z_$][\w$]*)\(\),/;
+  const match = code.match(pattern);
+  if (!match) throw new Error(`Pattern not found for ${label}`);
+
+  const replacement = `${match[0]}document.documentElement.dataset.codexOs===\`linux\`&&document.documentElement.classList.add(\`electron-opaque\`),`;
+  patches.push(label);
+  return code.slice(0, match.index) + replacement + code.slice(match.index + match[0].length);
+}
+
+function patchKeepElectronOpaque(code, patches) {
+  const label = "keep electron-opaque on linux";
+  const from = "if(C.opaqueWindows&&!wi()){e.classList.add(`electron-opaque`);return}e.classList.remove(`electron-opaque`)";
+  const to = "if((document.documentElement.dataset.codexOs===`linux`||C.opaqueWindows)&&!wi()){e.classList.add(`electron-opaque`);return}e.classList.remove(`electron-opaque`)";
+
+  if (code.includes(to) || code.includes("document.documentElement.dataset.codexOs===`linux`||")) return code;
+  if (code.includes(from)) {
+    patches.push(label);
+    return code.replace(from, to);
+  }
+
+  const pattern = /if\(([A-Za-z_$][\w$]*)\.opaqueWindows&&!([A-Za-z_$][\w$]*)\(\)\)\{([A-Za-z_$][\w$]*)\.classList\.add\(`electron-opaque`\);return\}\3\.classList\.remove\(`electron-opaque`\)/;
+  const match = code.match(pattern);
+  if (!match) throw new Error(`Pattern not found for ${label}`);
+
+  const [, stateVar, translucentFn, elementVar] = match;
+  const replacement = `if((document.documentElement.dataset.codexOs===\`linux\`||${stateVar}.opaqueWindows)&&!${translucentFn}()){${elementVar}.classList.add(\`electron-opaque\`);return}${elementVar}.classList.remove(\`electron-opaque\`)`;
+  patches.push(label);
+  return code.slice(0, match.index) + replacement + code.slice(match.index + match[0].length);
+}
+
 function writeIfChanged(bundle, before, after, patches, check) {
   if (patches.length === 0) {
     console.log(`  [ok] ${relPath(bundle.path)}: already patched`);
@@ -40,21 +145,8 @@ function patchMainBundle(bundle, check) {
   let code = before;
   const patches = [];
 
-  code = replaceOnce(
-    code,
-    "function QW({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`win32`&&!YW(t)?n?{backgroundColor:r?AW:jW,backgroundMaterial:`none`}:{backgroundColor:kW,backgroundMaterial:`mica`}:{backgroundColor:kW,backgroundMaterial:null}}",
-    "function QW({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`linux`&&!YW(t)?{backgroundColor:r?AW:jW,backgroundMaterial:null}:e===`win32`&&!YW(t)?n?{backgroundColor:r?AW:jW,backgroundMaterial:`none`}:{backgroundColor:kW,backgroundMaterial:`mica`}:{backgroundColor:kW,backgroundMaterial:null}}",
-    "linux opaque BrowserWindow background",
-    patches,
-  );
-
-  code = replaceOnce(
-    code,
-    "function eG({appearance:e,opaqueWindowsEnabled:t,platform:n}){switch(e){case`browserCommentPopup`:",
-    "function eG({appearance:e,opaqueWindowsEnabled:t,platform:n}){if(n===`linux`&&(e===`primary`||e===`secondary`))return{titleBarStyle:`default`,transparent:!1};switch(e){case`browserCommentPopup`:",
-    "linux non-transparent primary windows",
-    patches,
-  );
+  code = patchOpaqueBackground(code, patches);
+  code = patchLinuxWindowOptions(code, patches);
 
   writeIfChanged(bundle, before, code, patches, check);
 }
@@ -64,21 +156,8 @@ function patchRendererBundle(bundle, check) {
   let code = before;
   const patches = [];
 
-  code = replaceOnce(
-    code,
-    "document.documentElement.dataset.codexOs=FF(),",
-    "document.documentElement.dataset.codexOs=FF(),document.documentElement.dataset.codexOs===`linux`&&document.documentElement.classList.add(`electron-opaque`),",
-    "linux electron-opaque class at startup",
-    patches,
-  );
-
-  code = replaceOnce(
-    code,
-    "if(C.opaqueWindows&&!wi()){e.classList.add(`electron-opaque`);return}e.classList.remove(`electron-opaque`)",
-    "if((document.documentElement.dataset.codexOs===`linux`||C.opaqueWindows)&&!wi()){e.classList.add(`electron-opaque`);return}e.classList.remove(`electron-opaque`)",
-    "keep electron-opaque on linux",
-    patches,
-  );
+  code = patchElectronOpaqueStartup(code, patches);
+  code = patchKeepElectronOpaque(code, patches);
 
   writeIfChanged(bundle, before, code, patches, check);
 }

--- a/scripts/prepare-src.js
+++ b/scripts/prepare-src.js
@@ -7,7 +7,7 @@
  *   2. Replace codex binary with @cometix/codex version
  *   3. Copy everything to src/ for forge (app.asar + unpacked + resources)
  *
- * For Linux: strip macOS-only resources, add Linux codex from @cometix/codex
+ * For Linux: copy patched ASAR content into src/ and stage Linux-only resources.
  *
  * Usage:
  *   node scripts/prepare-src.js --platform mac-arm64
@@ -16,17 +16,15 @@
 const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
+const {
+  copyLinuxExecutable,
+  isMachO,
+  resolveCodexVendor,
+  resolveRipgrepVendor,
+} = require("./linux-native-utils");
 
 const SRC = path.join(__dirname, "..", "src");
 const PROJECT_ROOT = path.join(__dirname, "..");
-
-const TARGET_TRIPLE_MAP = {
-  "mac-arm64": "aarch64-apple-darwin",
-  "mac-x64": "x86_64-apple-darwin",
-  "linux-x64": "x86_64-unknown-linux-musl",
-  "linux-arm64": "aarch64-unknown-linux-musl",
-  "win": "x86_64-pc-windows-msvc",
-};
 
 // macOS-only resources to strip for Linux
 const MACOS_STRIP = new Set([
@@ -50,69 +48,217 @@ function copyRecursive(src, dest, skipFiles, skipDirs) {
   return count;
 }
 
-/**
- * Resolve codex CLI binary from @cometix/codex.
- * Tries node_modules first, falls back to npm pack + extract.
- */
-function resolveCodexVendor(platform) {
-  const triple = TARGET_TRIPLE_MAP[platform];
-  if (!triple) return null;
-  const isWin = platform === "win";
-  const binName = isWin ? "codex.exe" : "codex";
+function rmIfExists(target) {
+  if (fs.existsSync(target)) fs.rmSync(target, { recursive: true, force: true });
+}
 
-  // 1. Try platform-specific package (0.128+)
-  const PLAT_PKG = {
-    "linux-x64": "codex-linux-x64", "linux-arm64": "codex-linux-arm64",
-    "mac-arm64": "codex-darwin-arm64", "mac-x64": "codex-darwin-x64", "win": "codex-win32-x64",
-  };
-  const pkg = PLAT_PKG[platform];
-  if (pkg) {
-    const p = path.join(PROJECT_ROOT, "node_modules", "@cometix", pkg, "vendor", triple, "codex", binName);
-    if (fs.existsSync(p)) return p;
+function removeMachOFiles(dir, options = {}) {
+  let removed = 0;
+  if (!fs.existsSync(dir)) return removed;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (options.skipDirNames?.has(entry.name)) continue;
+    const target = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      removed += removeMachOFiles(target, options);
+      try {
+        if (fs.existsSync(target) && fs.readdirSync(target).length === 0) fs.rmdirSync(target);
+      } catch {}
+    } else if (entry.isFile() && isMachO(target)) {
+      fs.unlinkSync(target);
+      removed++;
+    }
   }
-  // 2. Try old-style vendor (pre-0.128)
-  const localPath = path.join(PROJECT_ROOT, "node_modules", "@cometix", "codex", "vendor", triple, "codex", binName);
-  if (fs.existsSync(localPath)) return localPath;
+  return removed;
+}
 
-  // 3. npm pack platform package
-  const PLAT_SUFFIX = {
-    "linux-x64": "linux-x64", "linux-arm64": "linux-arm64",
-    "mac-arm64": "darwin-arm64", "mac-x64": "darwin-x64", "win": "win32-x64",
-  };
-  const suffix = PLAT_SUFFIX[platform];
-  if (!suffix) return null;
+function removeNonLinuxPrebuilds(dir, platform) {
+  let removed = 0;
+  if (!fs.existsSync(dir)) return removed;
+  const keepLinuxArch = platform === "linux-arm64" ? "linux-arm64" : "linux-x64";
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const target = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "prebuilds") {
+        for (const prebuild of fs.readdirSync(target, { withFileTypes: true })) {
+          const prebuildPath = path.join(target, prebuild.name);
+          if (prebuild.isDirectory() && prebuild.name !== keepLinuxArch) {
+            rmIfExists(prebuildPath);
+            removed++;
+          }
+        }
+      } else {
+        removed += removeNonLinuxPrebuilds(target, platform);
+      }
+    }
+  }
+  return removed;
+}
 
-  let baseVer;
-  try {
-    baseVer = execSync("npm view @cometix/codex version", { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-  } catch { return null; }
-
-  const spec = `@cometix/codex@${baseVer}-${suffix}`;
-  console.log(`   [codex] fetching ${spec} via npm pack...`);
-  const tmpDir = path.join(require("os").tmpdir(), "cometix-codex-pack");
+function copyNpmPackageSource(moduleName, version, dest) {
+  const tmpDir = path.join(require("os").tmpdir(), "codex-native-source-pack", `${moduleName}-${version}`);
+  const extractDir = path.join(tmpDir, "extracted");
   fs.mkdirSync(tmpDir, { recursive: true });
 
-  try {
-    const tgzName = execSync(`npm pack ${spec} --pack-destination "${tmpDir}"`, {
-      cwd: tmpDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"],
-    }).trim().split("\n").pop();
+  console.log(`   [linux] fetching ${moduleName}@${version} source via npm pack...`);
+  const tgzName = execSync(`npm pack ${moduleName}@${version} --pack-destination "${tmpDir}"`, {
+    cwd: tmpDir,
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim().split("\n").pop();
 
-    const extractDir = path.join(tmpDir, "extracted");
-    if (fs.existsSync(extractDir)) fs.rmSync(extractDir, { recursive: true });
-    fs.mkdirSync(extractDir, { recursive: true });
-    execSync(`tar xzf "${path.join(tmpDir, tgzName)}" -C "${extractDir}"`, { stdio: "pipe" });
+  rmIfExists(extractDir);
+  fs.mkdirSync(extractDir, { recursive: true });
+  execSync(`tar xzf "${path.join(tmpDir, tgzName)}" -C "${extractDir}"`, { stdio: "pipe" });
+  copyRecursive(path.join(extractDir, "package"), dest);
+}
 
-    const vendorPath = path.join(extractDir, "package", "vendor", triple, "codex", binName);
-    if (fs.existsSync(vendorPath)) return vendorPath;
-  } catch (e) {
-    console.log(`   [!] npm pack failed: ${e.message}`);
+function copyNativeSourceModule(moduleName) {
+  const source = path.join(PROJECT_ROOT, "node_modules", moduleName);
+  const dest = path.join(SRC, "node_modules", moduleName);
+  const runtimePkgPath = path.join(dest, "package.json");
+  const runtimeVersion = fs.existsSync(runtimePkgPath)
+    ? JSON.parse(fs.readFileSync(runtimePkgPath, "utf-8")).version
+    : null;
+  if (!runtimeVersion) {
+    console.error(`[x] Upstream runtime dependency not found: ${moduleName}`);
+    process.exit(1);
   }
 
-  return null;
+  let copiedFrom = null;
+  const sourcePkgPath = path.join(source, "package.json");
+  if (fs.existsSync(sourcePkgPath)) {
+    const sourceVersion = JSON.parse(fs.readFileSync(sourcePkgPath, "utf-8")).version;
+    if (sourceVersion === runtimeVersion) copiedFrom = source;
+  }
+
+  rmIfExists(dest);
+  if (copiedFrom) {
+    copyRecursive(copiedFrom, dest);
+  } else {
+    copyNpmPackageSource(moduleName, runtimeVersion, dest);
+  }
+  console.log(`   [linux] ${moduleName}: copied buildable sources (${runtimeVersion})`);
+}
+
+function stageLinuxResources(platform, sourceDir) {
+  const resourceDir = path.join(SRC, ".linux-resources", platform);
+  rmIfExists(resourceDir);
+  fs.mkdirSync(resourceDir, { recursive: true });
+
+  const skipFiles = new Set([
+    ...MACOS_STRIP,
+    "app.asar",
+    "codex",
+    "rg",
+  ]);
+  const skipDirs = new Set([
+    ...MACOS_STRIP_DIRS,
+    "_asar",
+    "app.asar.unpacked",
+  ]);
+  let resourceCount = 0;
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    if (entry.name.endsWith(".lproj")) continue;
+    if (skipFiles.has(entry.name) || skipDirs.has(entry.name)) continue;
+    const sourcePath = path.join(sourceDir, entry.name);
+    const destPath = path.join(resourceDir, entry.name);
+    if (entry.isDirectory()) resourceCount += copyRecursive(sourcePath, destPath);
+    else if (!entry.isSymbolicLink()) {
+      fs.copyFileSync(sourcePath, destPath);
+      resourceCount++;
+    }
+  }
+  const removed = removeMachOFiles(resourceDir);
+  const removedPrebuilds = removeNonLinuxPrebuilds(resourceDir, platform);
+  console.log(`   [linux] staged ${resourceCount} sanitized resource files (${removed} Mach-O, ${removedPrebuilds} non-target prebuild dirs removed)`);
+
+  const codex = resolveCodexVendor(platform);
+  if (!codex) {
+    console.error(`[x] Linux codex ELF not found for ${platform}`);
+    process.exit(1);
+  }
+  copyLinuxExecutable(codex, path.join(resourceDir, "codex"), platform, "codex");
+  console.log("   [linux] staged codex ELF");
+
+  const rg = resolveRipgrepVendor(platform);
+  if (!rg) {
+    console.error(`[x] Linux ripgrep ELF not found for ${platform}`);
+    process.exit(1);
+  }
+  copyLinuxExecutable(rg, path.join(resourceDir, "rg"), platform, "rg");
+  console.log("   [linux] staged rg ELF");
+}
+
+function stripLinuxMacArtifacts(linuxRoot) {
+  let removed = 0;
+  for (const name of MACOS_STRIP) {
+    const target = path.join(linuxRoot, name);
+    if (fs.existsSync(target)) {
+      rmIfExists(target);
+      removed++;
+    }
+  }
+  for (const name of MACOS_STRIP_DIRS) {
+    const target = path.join(linuxRoot, name);
+    if (fs.existsSync(target)) {
+      rmIfExists(target);
+      removed++;
+    }
+  }
+
+  const linuxNodeModules = path.join(linuxRoot, "node_modules");
+  const knownNativeStripPaths = [
+    path.join(linuxNodeModules, "better-sqlite3", "build", "Release", "better_sqlite3.node"),
+    path.join(linuxNodeModules, "node-pty", "build", "Release", "pty.node"),
+    path.join(linuxNodeModules, "node-pty", "build", "Release", "spawn-helper"),
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "darwin-x64"),
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "darwin-arm64"),
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "win32-x64"),
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "win32-arm64"),
+  ];
+
+  for (const target of knownNativeStripPaths) {
+    if (fs.existsSync(target)) {
+      rmIfExists(target);
+      removed++;
+    }
+  }
+
+  removed += removeMachOFiles(linuxRoot, { skipDirNames: new Set(["mac-arm64", "mac-x64"]) });
+
+  console.log(`   [linux] stripped ${removed} macOS-only native/resource paths`);
+}
+
+function stripLinuxNativeBuildExtras() {
+  let removed = 0;
+  const linuxNodeModules = path.join(SRC, "node_modules");
+  const stripPaths = [
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "darwin-x64"),
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "darwin-arm64"),
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "win32-x64"),
+    path.join(linuxNodeModules, "node-pty", "prebuilds", "win32-arm64"),
+    path.join(linuxNodeModules, "node-pty", "build", "Release", "obj.target"),
+    path.join(linuxNodeModules, "better-sqlite3", "build", "Release", "obj.target"),
+    path.join(linuxNodeModules, "better-sqlite3", "build", "Release", "obj"),
+    path.join(linuxNodeModules, "better-sqlite3", "build", "Release", "test_extension.node"),
+  ];
+  for (const target of stripPaths) {
+    if (fs.existsSync(target)) {
+      rmIfExists(target);
+      removed++;
+    }
+  }
+  removed += removeMachOFiles(SRC, { skipDirNames: new Set(["mac-arm64", "mac-x64"]) });
+  console.log(`-- strip-linux-native-extras: removed ${removed} non-Linux/intermediate native paths`);
 }
 
 function main() {
   const args = process.argv.slice(2);
+  if (args.includes("--strip-linux-native-extras")) {
+    stripLinuxNativeBuildExtras();
+    return;
+  }
+
   const platIdx = args.indexOf("--platform");
   const platform = platIdx !== -1 ? args[platIdx + 1] : null;
 
@@ -141,24 +287,33 @@ function main() {
   console.log(`-- prepare-src: ${platform}`);
   console.log(`   source: ${path.relative(PROJECT_ROOT, sourceDir)}/`);
 
-  // 1. Repack _asar/ -> app.asar
-  const repackedAsar = path.join(sourceDir, "app.asar");
-  console.log("   [repack] _asar/ -> app.asar");
-  execSync(`npx asar pack "${asarContentDir}" "${repackedAsar}"`);
-  const asarSize = (fs.statSync(repackedAsar).size / 1048576).toFixed(1);
-  console.log(`   [ok] app.asar: ${asarSize} MB`);
+  // 1. Repack _asar/ -> app.asar for platforms that ship upstream Resources.
+  // Linux must let Electron Forge create app.asar/app.asar.unpacked from src/.
+  if (!isLinux) {
+    const repackedAsar = path.join(sourceDir, "app.asar");
+    console.log("   [repack] _asar/ -> app.asar");
+    execSync(`npx asar pack "${asarContentDir}" "${repackedAsar}"`);
+    const asarSize = (fs.statSync(repackedAsar).size / 1048576).toFixed(1);
+    console.log(`   [ok] app.asar: ${asarSize} MB`);
+  } else {
+    console.log("   [linux] Forge will pack app.asar from src/");
+  }
 
-  // 2. Replace codex binary with @cometix/codex
+  // 2. Replace or stage codex binary
   const isWin = platform === "win";
   const codexBinName = isWin ? "codex.exe" : "codex";
-  const vendorCodex = resolveCodexVendor(platform);
-  if (vendorCodex) {
-    const dest = path.join(sourceDir, codexBinName);
-    fs.copyFileSync(vendorCodex, dest);
-    try { fs.chmodSync(dest, 0o755); } catch {}
-    console.log(`   [codex] replaced with @cometix/codex`);
+  if (isLinux) {
+    stageLinuxResources(platform, sourceDir);
   } else {
-    console.log(`   [!] @cometix/codex vendor not found for ${platform}, keeping upstream`);
+    const vendorCodex = resolveCodexVendor(platform);
+    if (vendorCodex) {
+      const dest = path.join(sourceDir, codexBinName);
+      fs.copyFileSync(vendorCodex, dest);
+      try { fs.chmodSync(dest, 0o755); } catch {}
+      console.log(`   [codex] replaced with @cometix/codex`);
+    } else {
+      console.log(`   [!] @cometix/codex vendor not found for ${platform}, keeping upstream`);
+    }
   }
 
   // 3. For Linux: copy _asar/ content to flat src/ (forge packs ASAR from src/)
@@ -174,6 +329,9 @@ function main() {
     }
     const count = copyRecursive(asarContentDir, SRC);
     console.log(`   [linux] _asar/ -> src/ (${count} files for forge ASAR packing)`);
+    copyNativeSourceModule("better-sqlite3");
+    copyNativeSourceModule("node-pty");
+    stripLinuxMacArtifacts(SRC);
   }
 
   // 4. Sync version to root package.json

--- a/scripts/sync-upstream.js
+++ b/scripts/sync-upstream.js
@@ -71,10 +71,18 @@ function extractArchive(archive, dest) {
     // ditto preserves macOS symlinks + resource forks (required for .app)
     execSync(`ditto -xk "${archive}" "${dest}"`);
   } else {
-    // 7zz for Windows MSIX and Linux (symlinks don't matter — only ASAR content used)
+    // 7zz/7z for Windows MSIX and Linux (symlinks don't matter — only ASAR content used)
     for (const bin of ["7zz", "7z"]) {
       try {
         execSync(`${bin} x -y -o"${dest}" "${archive}"`, { stdio: "pipe" });
+        return;
+      } catch {
+        if (fs.readdirSync(dest).length > 0) return;
+      }
+    }
+    if (archive.endsWith(".zip")) {
+      try {
+        execSync(`unzip -q "${archive}" -d "${dest}"`, { stdio: "pipe" });
         return;
       } catch {
         if (fs.readdirSync(dest).length > 0) return;

--- a/scripts/validate-linux-package.js
+++ b/scripts/validate-linux-package.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+const {
+  assertLinuxElf,
+  isElf,
+  isMachO,
+} = require("./linux-native-utils");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+
+function usage() {
+  console.error("Usage: node scripts/validate-linux-package.js [--arch x64|arm64] [--deb path] [--dir path]");
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const result = { arch: "x64", deb: null, dir: null };
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--arch") result.arch = args[++i];
+    else if (arg === "--deb") result.deb = args[++i];
+    else if (arg === "--dir") result.dir = args[++i];
+    else {
+      usage();
+      process.exit(2);
+    }
+  }
+  if (!["x64", "arm64"].includes(result.arch)) {
+    usage();
+    process.exit(2);
+  }
+  return result;
+}
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(fullPath, out);
+    else if (entry.isFile()) out.push(fullPath);
+  }
+  return out;
+}
+
+function findDeb(arch) {
+  const debDir = path.join(PROJECT_ROOT, "out", "make", "deb", arch);
+  if (!fs.existsSync(debDir)) return null;
+  const debs = fs.readdirSync(debDir)
+    .filter((name) => name.endsWith(".deb"))
+    .map((name) => path.join(debDir, name))
+    .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+  return debs[0] || null;
+}
+
+function extractDeb(debPath) {
+  const outDir = path.join(os.tmpdir(), `codex-linux-package-${process.pid}`);
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+  execFileSync("dpkg-deb", ["-x", debPath, outDir], { stdio: "inherit" });
+  return outDir;
+}
+
+function relative(root, filePath) {
+  return path.relative(root, filePath).split(path.sep).join("/");
+}
+
+function findBySuffix(files, suffix) {
+  return files.find((filePath) => relative("/", filePath).endsWith(suffix));
+}
+
+function validate(root, arch) {
+  const platform = arch === "arm64" ? "linux-arm64" : "linux-x64";
+  const files = walk(root);
+  const failures = [];
+
+  const machoFiles = files.filter(isMachO);
+  if (machoFiles.length > 0) {
+    failures.push(`Mach-O files found:\n${machoFiles.map((filePath) => `  - ${relative(root, filePath)}`).join("\n")}`);
+  }
+
+  const nodeFiles = files.filter((filePath) => filePath.endsWith(".node"));
+  for (const nodeFile of nodeFiles) {
+    if (!isElf(nodeFile)) {
+      failures.push(`Native module is not ELF: ${relative(root, nodeFile)}`);
+    } else {
+      try {
+        assertLinuxElf(nodeFile, platform, relative(root, nodeFile));
+      } catch (e) {
+        failures.push(e.message);
+      }
+    }
+  }
+
+  const betterSqlite = findBySuffix(
+    files,
+    "resources/app.asar.unpacked/src/node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+  );
+  if (!betterSqlite) {
+    failures.push("better-sqlite3 native module not found in app.asar.unpacked/src/node_modules");
+  } else {
+    try {
+      assertLinuxElf(betterSqlite, platform, "better_sqlite3.node");
+    } catch (e) {
+      failures.push(e.message);
+    }
+  }
+
+  for (const name of ["codex", "rg"]) {
+    const resourceBinary = files.find((filePath) => path.basename(filePath) === name && relative(root, filePath).includes("/resources/"));
+    if (!resourceBinary) {
+      failures.push(`resources/${name} not found`);
+      continue;
+    }
+    try {
+      assertLinuxElf(resourceBinary, platform, name);
+    } catch (e) {
+      failures.push(e.message);
+    }
+  }
+
+  const macOnlyResources = [
+    "resources/native",
+    "resources/electron.icns",
+    "resources/Assets.car",
+    "resources/codex_chronicle",
+    "resources/node",
+    "resources/node_repl",
+  ];
+  for (const suffix of macOnlyResources) {
+    const found = files.some((filePath) => relative(root, filePath).endsWith(suffix))
+      || fs.existsSync(path.join(root, suffix));
+    if (found) failures.push(`macOS-only resource found: ${suffix}`);
+  }
+
+  console.log(`-- validate-linux-package: ${platform}`);
+  console.log(`   root: ${root}`);
+  console.log(`   files scanned: ${files.length}`);
+  console.log(`   native .node files: ${nodeFiles.length}`);
+  console.log(`   Mach-O files: ${machoFiles.length}`);
+  if (betterSqlite) console.log(`   better-sqlite3: ${relative(root, betterSqlite)}`);
+
+  if (failures.length > 0) {
+    console.error("\n[x] Linux package validation failed");
+    for (const failure of failures) console.error(`\n${failure}`);
+    process.exit(1);
+  }
+
+  console.log("   [ok] no Mach-O files and Linux native modules validated");
+}
+
+function main() {
+  const args = parseArgs();
+  let root = args.dir ? path.resolve(args.dir) : null;
+
+  if (!root) {
+    const debPath = args.deb ? path.resolve(args.deb) : findDeb(args.arch);
+    if (!debPath) {
+      console.error(`[x] No deb found for arch ${args.arch}`);
+      process.exit(1);
+    }
+    console.log(`   [deb] ${path.relative(PROJECT_ROOT, debPath)}`);
+    root = extractDeb(debPath);
+  }
+
+  if (!fs.existsSync(root)) {
+    console.error(`[x] Validation root not found: ${root}`);
+    process.exit(1);
+  }
+
+  validate(root, args.arch);
+}
+
+main();


### PR DESCRIPTION
## Summary
- fix Linux native module packaging and rebuild flow
- add Linux packaging validation and rendering patch helpers
- update packaging config, build workflow, and source preparation scripts for Linux builds

## Validation
- Built the Linux package locally
- Installed and used the generated Linux package for about one day without major issues

## Notes
This is opened as a draft PR because the changes were prepared and smoke-tested locally, but still need maintainer review before merge.

## Summary by Sourcery

Fix Linux packaging of native modules and resources by introducing shared Linux-native utilities, staging and sanitizing Linux resources during source preparation, and adjusting Electron Forge hooks and build scripts to rely on rebuilt Linux-native binaries from src/ rather than macOS bundles.

New Features:
- Add Linux-specific rendering patch script to force opaque window rendering paths and CSS on Linux compositors.
- Introduce Linux package validation script to ensure generated .deb archives contain only Linux ELF natives and no macOS-only resources.
- Provide Linux-native utilities for resolving and validating codex and ripgrep binaries and other ELF targets.

Enhancements:
- Update source preparation flow to stage sanitized Linux resources, copy buildable native module sources, and strip non-Linux artifacts before packaging.
- Refine Electron Forge configuration and hooks to support Linux builds that pack app.asar from src/ and copy staged Linux resources, including conditional RPM maker usage.
- Improve upstream archive extraction to support unzip when 7z/7zz are unavailable and expand Linux build scripts with arch-specific electron-rebuild commands and validation steps.

CI:
- Extend Linux CI job dependencies to include native build and validation tools required for Linux packaging.